### PR TITLE
Review and cleanup the C bindings

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@ environment:
 
 install:
   - appveyor DownloadFile https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/appveyor-opam.sh
-  - "%CYG_ROOT%\\setup-x86.exe -qnNdO -R %CYG_ROOT% -s http://cygwin.mirror.constant.com -l C:/cygwin/var/cache/setup -P rsync -P patch -P diffutils -P curl -P make -P unzip -P git -P m4 -P perl -P mingw64-x86_64-gcc-core"
+  - "%CYG_ROOT%\\setup-x86.exe -qnNdO -R %CYG_ROOT% -s http://cygwin.mirror.constant.com -l C:/cygwin/var/cache/setup -P rsync -P patch -P diffutils -P make -P unzip -P git -P m4 -P perl -P mingw64-x86_64-gcc-core"
 
 build_script:
   - "%CYG_BASH% '${APPVEYOR_BUILD_FOLDER}/appveyor-opam.sh'"

--- a/lib/named_pipe.ml
+++ b/lib/named_pipe.ml
@@ -26,7 +26,7 @@ module Server = struct
     if Sys.os_type <> "Win32" then raise Not_available;
     create' path
 
-  external connect': t -> bool = "stub_named_pipe_connect"
+  external connect': t -> unit = "stub_named_pipe_connect"
   let connect t =
     if Sys.os_type <> "Win32" then raise Not_available;
     connect' t
@@ -63,7 +63,7 @@ module Client = struct
       raise Pipe_busy
     | e -> raise e
 
-  external wait': string -> int -> bool = "stub_named_pipe_wait"
+  external wait': string -> int -> unit = "stub_named_pipe_wait"
 
   let wait path ms =
     if Sys.os_type <> "Win32" then raise Not_available;

--- a/lib/named_pipe.mli
+++ b/lib/named_pipe.mli
@@ -27,7 +27,7 @@ module Server: sig
   val create: string -> t
   (** The server should create a named pipe at a particular path under \\.\pipe *)
 
-  val connect: t -> bool
+  val connect: t -> unit
   (** Connect blocks until a client connects to this named pipe *)
 
   val to_fd: t -> Unix.file_descr
@@ -61,9 +61,8 @@ module Client: sig
 
   val to_fd: t -> Unix.file_descr
 
-  val wait: string -> int -> bool
+  val wait: string -> int -> unit
   (** [wait path ms] wait for up to [ms] milliseconds for the server to become
-      available. Returns true if the server has a free slot: in this case
-      the client should call [openpipe] again. Returns false if the server
-      has shutdown. *)
+      available. Returns when the server has a free slot: in this case
+      the client should call [openpipe] again. *)
 end

--- a/lwt/named_pipe_lwt.ml
+++ b/lwt/named_pipe_lwt.ml
@@ -32,7 +32,7 @@ module Server = struct
     if Sys.os_type <> "Win32" then raise Not_available;
     create' path
 
-  external connect_job: t -> bool Lwt_unix.job = "named_pipe_lwt_connect_job"
+  external connect_job: t -> unit Lwt_unix.job = "named_pipe_lwt_connect_job"
 
   let connect t =
     if Sys.os_type <> "Win32" then raise Not_available;
@@ -63,7 +63,7 @@ module Client = struct
 
   let to_fd x = Lwt_unix.of_unix_file_descr ~blocking:true x
 
-  external wait_job: string -> int -> bool Lwt_unix.job = "named_pipe_lwt_wait_job"
+  external wait_job: string -> int -> unit Lwt_unix.job = "named_pipe_lwt_wait_job"
 
   let wait path ms =
     if Sys.os_type <> "Win32" then raise Not_available;
@@ -76,8 +76,7 @@ module Client = struct
       Lwt.return fd
     with Unix.Unix_error(Unix.EUNKNOWNERR -231, _, _) ->
       (* ERROR_PIPE_BUSY *)
-      wait path 1000
-      >>= fun _ ->
+      wait path 1000 >>= fun () ->
       openpipe path
     | e -> raise e
 

--- a/lwt/named_pipe_lwt.mli
+++ b/lwt/named_pipe_lwt.mli
@@ -31,7 +31,7 @@ module Server: sig
   val create: string -> t
   (** The server should create a named pipe at a particular path under \\.\pipe *)
 
-  val connect: t -> bool Lwt.t
+  val connect: t -> unit Lwt.t
   (** Connect blocks until a client connects to this named pipe *)
 
   val to_fd: t -> Lwt_unix.file_descr
@@ -55,7 +55,7 @@ module Client: sig
   val openpipe: string -> t Lwt.t
   (** Connect to the named pipe server on the given path (e.g. \\.\pipe\foo).
       If the server isn't running then this raises Unix_error(Unix.ENOENT...).
-      If the server is busy then this function blocks. *) 
+      If the server is busy then this function blocks. *)
 
   val to_fd: t -> Lwt_unix.file_descr
 end


### PR DESCRIPTION
- improve error reporting: GetLastError() is now always called and an
  exception is raised with the full error;
- free up lwt_jobs objects;
- connect and wait now return `unit` but raise Unix.Error in case of error
  (as other unix-like socket functions).